### PR TITLE
Ensure we allow enable/disable hooks globally from the public API

### DIFF
--- a/lib/ecto_hooks/repo.ex
+++ b/lib/ecto_hooks/repo.ex
@@ -138,8 +138,8 @@ defmodule EctoHooks.Repo do
   loops provided.
 
   If you wish to opt in, opt out, or introspect the state of these mitigations, please
-  see the documentation for the following functions: `EctoHooks.enable_hooks/0`,
-  `EctoHooks.disable_hooks/0`, `EctoHooks.hooks_enabled?/0` and `EctoHooks.in_hook?/0`.
+  see the documentation for the following functions: `EctoHooks.enable_hooks/1`,
+  `EctoHooks.disable_hooks/1`, `EctoHooks.hooks_enabled?/0` and `EctoHooks.in_hook?/0`.
 
   This is a very powerful tool, and admittedly quite hidden and hard to track down.
   Trying to avoid adding too much business logic in your EctoHooks is wise for both

--- a/lib/ecto_hooks/state.ex
+++ b/lib/ecto_hooks/state.ex
@@ -1,22 +1,26 @@
 defmodule EctoHooks.State do
   @moduledoc false
 
-  @doc """
-  Disables EctoHooks from running for all future Repo operations in the current process.
-  """
-  def disable_hooks, do: put_state(:hooks_enabled, false)
+  @doc false
+  def disable_hooks([global: global] \\ [global: true]),
+    do: put_state({global, :hooks_enabled}, false)
 
-  @doc """
-  Enables EctoHooks from running for all future Repo operations in the current process.
-  """
-  def enable_hooks, do: put_state(:hooks_enabled, true)
+  @doc false
+  def enable_hooks([global: global] \\ [global: true]),
+    do: put_state({global, :hooks_enabled}, true)
 
   @doc """
   Returns a boolean indicating if EctoHooks are enabled in the current process.
 
   If `true`, hooks will not be triggered for Repo operations.
   """
-  def hooks_enabled?, do: get_state(:hooks_enabled, true)
+  def hooks_enabled? do
+    if get_state({true, :hooks_enabled}, true) do
+      get_state({false, :hooks_enabled}, true)
+    else
+      false
+    end
+  end
 
   @doc """
   Utility function which returns true if currently executing inside the context of an
@@ -30,7 +34,7 @@ defmodule EctoHooks.State do
   By default, every hook will "acquire" an EctoHook context and increment a ref count.
   These ref counts are automatically decremented once a hook finishes running.
 
-  This is provided as a lower level alternative the `enable_hooks/0`, `disable_hooks/0`,
+  This is provided as a lower level alternative the `enable_hooks/1`, `disable_hooks/1`,
   and `hooks_enabled?/0` functions.
   """
   def hooks_ref_count, do: get_state(:ref_count, 0)

--- a/test/ecto_hooks/state_test.exs
+++ b/test/ecto_hooks/state_test.exs
@@ -3,45 +3,45 @@ defmodule EctoHooks.StateTest do
 
   alias EctoHooks.State
 
-  describe "disable_hooks/0" do
+  describe "disable_hooks/1" do
     test "when already enabled, disables hooks such that `hooks_enabled?/0` returns false" do
       assert State.hooks_enabled?()
-      assert :ok = State.disable_hooks()
+      assert :ok = State.disable_hooks(global: false)
       refute State.hooks_enabled?()
     end
 
     test "disabling hooks multiple times is a noop" do
       assert State.hooks_enabled?()
-      assert :ok = State.disable_hooks()
-      assert :ok = State.disable_hooks()
+      assert :ok = State.disable_hooks(global: false)
+      assert :ok = State.disable_hooks(global: false)
       refute State.hooks_enabled?()
     end
   end
 
-  describe "enable_hooks/0" do
+  describe "enable_hooks/1" do
     test "when already enabled, disables hooks such that `hooks_enabled?/0` returns false" do
-      assert :ok = State.disable_hooks()
+      assert :ok = State.disable_hooks(global: false)
       refute State.hooks_enabled?()
-      assert :ok = State.enable_hooks()
+      assert :ok = State.enable_hooks(global: false)
       assert State.hooks_enabled?()
     end
 
     test "enabling hooks multiple times is a noop" do
       assert State.hooks_enabled?()
-      assert :ok = State.enable_hooks()
-      assert :ok = State.enable_hooks()
+      assert :ok = State.enable_hooks(global: false)
+      assert :ok = State.enable_hooks(global: false)
       assert State.hooks_enabled?()
     end
   end
 
   describe "hooks_enabled?/0" do
     test "returns true if hooks enabled" do
-      assert :ok = State.enable_hooks()
+      assert :ok = State.enable_hooks(global: false)
       assert State.hooks_enabled?()
     end
 
     test "returns false if hooks disabled" do
-      assert :ok = State.disable_hooks()
+      assert :ok = State.disable_hooks(global: false)
       refute State.hooks_enabled?()
     end
   end


### PR DESCRIPTION
Previously, calling `EctoHooks.disable_hooks()` wouldn't do what you'd expect and would not stop hooks from firing.

With this change, we maintain our own state internally, for the duration of the hook execution, while allowing users of the library to actually disable/re-enable the hooks for as long as they need it.