### PR TITLE
Misc - mark callbacks in `EctoHooks` as optional, update docs

### DIFF
--- a/lib/ecto_hooks.ex
+++ b/lib/ecto_hooks.ex
@@ -38,6 +38,14 @@ defmodule EctoHooks do
   @callback after_update(schema_struct :: struct(), delta :: Delta.t()) :: struct()
   @callback after_delete(schema_struct :: struct(), delta :: Delta.t()) :: struct()
 
+  @optional_callbacks before_insert: 1,
+                      before_update: 1,
+                      before_delete: 1,
+                      after_get: 2,
+                      after_insert: 2,
+                      after_update: 2,
+                      after_delete: 2
+
   @doc """
   Alternative interface for initializing EctoHooks when `use`-ed in a module as follows:
 

--- a/lib/ecto_hooks/repo.ex
+++ b/lib/ecto_hooks/repo.ex
@@ -19,7 +19,7 @@ defmodule EctoHooks.Repo do
       adapter: Ecto.Adapters.Postgres
   end
 
-  def MyApp.User do
+  defmodule MyApp.User do
     use Ecto.Schema
     require Logger
 
@@ -35,6 +35,24 @@ defmodule EctoHooks.Repo do
       changeset
     end
 
+    def after_get(%__MODULE__{} = user, %EctoHooks.Delta{}) do
+      %__MODULE__{user | full_name: user.first_name <> " " <> user.last_name}
+    end
+  end
+  ```
+
+  As an aside, for documentation and potential code-completion purposes, you may also
+  annotate your `Ecto.Schema` modules with the following:
+
+  ```elixir
+  defmodule MyApp.User do
+    use Ecto.Schema
+    @behaviour EctoHooks
+
+    ...
+
+
+    @impl EctoHooks
     def after_get(%__MODULE__{} = user, %EctoHooks.Delta{}) do
       %__MODULE__{user | full_name: user.first_name <> " " <> user.last_name}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoHooks.MixProject do
     [
       aliases: aliases(),
       app: :ecto_hooks,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.13",
       elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fixes an issue where you could not add `@behaviour EctoHooks` and `@impl EctoHooks` to expected callbacks unless they were all defined.

Updates (and fixes a small typo) in docs.
